### PR TITLE
修复 Docker/多容器环境下图片防撤回转发失败的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,7 +138,7 @@ async def _process_component_and_get_gocq_part(
         local_path = await _download_and_cache_image(session, comp, temp_path)
         if local_path:
             local_files_to_cleanup.append(local_path)
-            gocq_parts.append({"type": "image", "data": {"file": local_path}})
+            gocq_parts.append({"type": "image", "data": {"file": f"file:///{local_path}"}})
         else:
             gocq_parts.append({"type": "text", "data": {"text": "[图片转发失败]"}})
     elif comp_type_name == 'Video':

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,4 +3,4 @@ display_name: QQ防撤回插件 # 用于展示的名字，可以是方便人类�
 desc: 可以监控指定群聊会话撤回的消息并发送给目标会话。 # 插件简短描述
 version: v1.1.4 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Foolllll # 作者
-repo: https://github.com/Foolllll-J/astrbot_plugin_anti_revoke # 插件的仓库地址
+repo: https://github.com/Thetail001/astrbot_plugin_anti_revoke # 插件的仓库地址

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,4 +3,4 @@ display_name: QQ防撤回插件 # 用于展示的名字，可以是方便人类�
 desc: 可以监控指定群聊会话撤回的消息并发送给目标会话。 # 插件简短描述
 version: v1.1.4 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Foolllll # 作者
-repo: https://github.com/Thetail001/astrbot_plugin_anti_revoke # 插件的仓库地址
+repo: https://github.com/Foolllll-J/astrbot_plugin_anti_revoke # 插件的仓库地址


### PR DESCRIPTION
问题背景 (Problem)
  在 Docker 或多容器部署环境下（例如 AstrBot 与 NapCat 分别运行在不同的容器中），由于容器间的文件系统是隔离的，插件尝试通过本地文件路径（file:///...）转发图片时，底层的适配器往往无法访问 AstrBot 容器内的临时文件，从而导致转发失败，报错信息通常为 识别URL失败 或 ENOENT: no such file or
  directory。

  解决方案 (Solution)
  将图片组件的转发逻辑从“传递本地文件路径”优化为“直接传递 Base64 编码数据”。
  通过 base64:// 协议传输图片流，可以绕过文件系统的物理路径限制，确保图片数据能直接通过 API 成功送达适配器。

  主要改动 (Changes)
   1. 在 main.py 中引入 base64 模块。
   2. 优化 _process_component_and_get_gocq_part 函数中的 Image 处理逻辑：在下载图片到本地缓存后，读取其内容并转换为 Base64 字符串进行转发。

  影响 (Impact)
  显著提升了插件在不同部署环境（尤其是 Docker 容器化部署）下的兼容性和稳定性。

 这是我对自己遇到的一些问题的改进，作者能考虑一下更改为这种传递base64吗？关于文件和视频我还没想到更好的办法，不太清除是否能获取原消息体里的链接，不过实际上QQ群里最常见的撤回之一就是图片，所以想着先这样改了。

## Summary by Sourcery

将图片转发方式从使用本地文件路径改为使用 Base64 编码数据，以提升在容器化环境中的兼容性。

Bug 修复：
- 修复在 Docker 或多容器部署中，由于本地文件路径不可访问而导致的图片防撤回转发失败问题。

增强功能：
- 为图片组件添加 Base64 编码和错误处理机制，当处理失败时回退为文本占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Change image forwarding to use Base64-encoded data instead of local file paths to improve compatibility in containerized environments.

Bug Fixes:
- Fix image anti-revoke forwarding failures in Docker or multi-container deployments caused by inaccessible local file paths.

Enhancements:
- Add Base64 encoding and error handling for image components, falling back to a text placeholder when processing fails.

</details>